### PR TITLE
NEW Make sure stubContext can accept promise objects

### DIFF
--- a/stub-azure-function-context.js
+++ b/stub-azure-function-context.js
@@ -63,7 +63,7 @@ function stubContext(functionUnderTest, triggers, outputs) {
         try {
             const result = functionUnderTest(context, ...Object.values(triggers));
             // async func
-            if (functionUnderTest && functionUnderTest.length) {
+            if (result && typeof result.then === 'function') {
                 result.then(context.done);
             }
         } catch (e) {

--- a/stub-azure-function-context.js
+++ b/stub-azure-function-context.js
@@ -61,7 +61,11 @@ function stubContext(functionUnderTest, triggers, outputs) {
         context.log.warn = wrapConsole('warn');
         context.log.verbose = wrapConsole('debug');
         try {
-            functionUnderTest(context, ...Object.values(triggers));
+            const result = functionUnderTest(context, ...Object.values(triggers));
+            // async func
+            if (functionUnderTest && functionUnderTest.length) {
+                result.then(context.done);
+            }
         } catch (e) {
             reject(e);
         }

--- a/test/stub-azure-function-context.spec.js
+++ b/test/stub-azure-function-context.spec.js
@@ -87,5 +87,24 @@ describe('stub-azure-function-context', () => {
                 context.done();
             });
         });
+        it('works with async functions', async () => {
+            const { context } = await stubContext(async (ctx) => {
+                Object.assign(ctx.res, {
+                    body: 'OK',
+                });
+            });
+            expect(context.res.body).to.equal('OK');
+        });
+        it('works with promises', async () => {
+            const { context } = await stubContext((ctx) => {
+                return new Promise((resolve) => {
+                    Object.assign(ctx.res, {
+                        body: 'OK',
+                    });
+                    resolve();
+                });
+            });
+            expect(context.res.body).to.equal('OK');
+        });
     });
 });


### PR DESCRIPTION
First off, thanks for this great library, we are using it extensively in one of our projects and it's really helping with testing.

Whilst refactoring one of our apps I noticed that when using `async` functions the mocha tests would timeout. I investigated a bit and it turns out that this library is depending on `context.done()` being called even when promises are returned. However this causes an error in the azure runtime.

This patch aims to allow the context stub to work with sync and async functions. Inspiration was taken from [mocha](https://github.com/mochajs/mocha/blob/v5.2.0/lib/runnable.js#L36)