### PR TITLE
Function fixes

### DIFF
--- a/stub-azure-function-context.js
+++ b/stub-azure-function-context.js
@@ -69,7 +69,13 @@ function stubContext(functionUnderTest, triggers, outputs) {
             const result = functionUnderTest(context, ...Object.values(triggers));
             // async func
             if (result && typeof result.then === 'function') {
-                result.then(context.done, context.done);
+                result.then((val) => {
+                    // see: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node#exporting-an-async-function
+                    Object.assign(context.bindings, {
+                        $return: val,
+                    });
+                    context.done();
+                }).catch(context.done);
             }
         } catch (e) {
             context.done(e);

--- a/stub-azure-function-context.js
+++ b/stub-azure-function-context.js
@@ -50,7 +50,7 @@ function stubContext(functionUnderTest, triggers, outputs) {
     if (outputs === undefined) {
         outputs = deepCopy(defaultOutputs); // eslint-disable-line no-param-reassign
     }
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         const context = {
             ...triggers,
             ...outputs,
@@ -72,7 +72,7 @@ function stubContext(functionUnderTest, triggers, outputs) {
                 result.then(context.done, context.done);
             }
         } catch (e) {
-            reject(e);
+            context.done(e);
         }
     });
 }

--- a/test/stub-azure-function-context.spec.js
+++ b/test/stub-azure-function-context.spec.js
@@ -87,6 +87,13 @@ describe('stub-azure-function-context', () => {
                 context.done();
             });
         });
+        it('handles thrown errors', async () => {
+            const chuckable = new Error('Unhandled error');
+            const { err } = await stubContext(() => {
+                throw chuckable;
+            });
+            expect(err).to.equal(chuckable);
+        });
         it('works with async functions which succeed', async () => {
             const { context } = await stubContext(async (ctx) => {
                 Object.assign(ctx.res, {

--- a/test/stub-azure-function-context.spec.js
+++ b/test/stub-azure-function-context.spec.js
@@ -120,6 +120,16 @@ describe('stub-azure-function-context', () => {
             });
             expect(context.res.body).to.equal('OK');
         });
+        it('sets the correct return binding for async', async () => {
+            const { context } = await stubContext(async () => {
+                return {
+                    body: 'test',
+                };
+            });
+            expect(context.bindings.$return).to.deep.equal({
+                body: 'test',
+            });
+        });
     });
     describe('.setContextLogger', () => {
         const logMethods = ['info', 'warn', 'error', 'verbose'];


### PR DESCRIPTION
Sorry for the multi-purpose PR.

1. non async functions that throw erroneously cause the context stub promise to be rejected, rather than returning the error in the `err` property
2. Async functions are allowed to return values and they end up in the `$return` binding (see https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node#exporting-an-async-function)