### PR TITLE
Add ability to pass a context manipulator when running a function

### DIFF
--- a/lib/bindings/table.js
+++ b/lib/bindings/table.js
@@ -24,7 +24,7 @@ function createTrigger(RowKey, PartitionKey, data) {
 }
 
 function handles({ type }) {
-    return ['blob', 'blobtrigger'].includes(type.toLowerCase());
+    return ['table', 'tabletrigger'].includes(type.toLowerCase());
 }
 
 module.exports = {

--- a/lib/context-builder.js
+++ b/lib/context-builder.js
@@ -1,4 +1,3 @@
-const uuid = require('uuid/v4');
 const bindings = require('./bindings');
 
 let logger = console;
@@ -22,8 +21,8 @@ function createBaseContext(bindingDefinitions) {
     };
 }
 
-function stubContextFromBindingDefinitions(bindingDefinitions) {
-    const context = createBaseContext(bindingDefinitions, uuid());
+function stubContextFromBindingDefinitions(bindingDefinitions, manipulator) {
+    const context = createBaseContext(bindingDefinitions);
     bindingDefinitions.forEach((definition) => {
         const handler = Object.values(bindings).find(({ handles }) => handles(definition));
         if (!handler) {
@@ -37,6 +36,9 @@ function stubContextFromBindingDefinitions(bindingDefinitions) {
             handler.addInputBinding(context, definition, definition.data);
         }
     });
+    if (typeof manipulator === 'function') {
+        manipulator(context);
+    }
     return context;
 }
 

--- a/lib/function-runner.js
+++ b/lib/function-runner.js
@@ -119,9 +119,19 @@ function callFunction(context, func, now) {
     });
 }
 
-function runStubFunctionFromBindings(func, bindingDefinitions = [], now) {
-    const context = stubContextFromBindingDefinitions(bindingDefinitions);
-    return callFunction(context, func, now);
+/**
+ *
+ * @param {function} func Function to test
+ * @param {Array.<{type: string, name: string, direction: string, ?data: *}>}bindingDefinitions
+ * @param {function} [amendContext] callback to manipulate the mocked context object
+ * @param {number} [now] timestamp representing the execution time
+ * @return {Promise.<*>}
+ */
+function runStubFunctionFromBindings(func, bindingDefinitions = [], amendContext, now) {
+    const contextCallback = typeof amendContext === 'function' ? amendContext : undefined;
+    const timestamp = contextCallback ? now : amendContext;
+    const context = stubContextFromBindingDefinitions(bindingDefinitions, contextCallback);
+    return callFunction(context, func, timestamp);
 }
 
 module.exports = {

--- a/lib/function-runner.js
+++ b/lib/function-runner.js
@@ -3,14 +3,14 @@ const { stubContextFromBindingDefinitions } = require('./context-builder');
 const moment = require('moment');
 
 function prepareContext(context, functionName = 'stubTest', resolver, now) {
-    const innvocationId = uuid();
+    const invocationId = uuid();
     const randGuid = uuid();
     Object.assign(context, {
-        innvocationId,
+        invocationId,
         done: resolver,
     });
     Object.assign(context.executionContext, {
-        innvocationId,
+        invocationId,
         functionName,
         functionDirectory: __dirname,
     });

--- a/test/function-runner.spec.js
+++ b/test/function-runner.spec.js
@@ -19,7 +19,7 @@ describe('runStubFunctionFromBindings', () => {
                 'bindingData',
                 'bindingDefinitions',
                 'req',
-                'innvocationId',
+                'invocationId',
                 'done',
             );
         });
@@ -53,7 +53,7 @@ describe('runStubFunctionFromBindings', () => {
                 'bindingData',
                 'bindingDefinitions',
                 'req',
-                'innvocationId',
+                'invocationId',
                 'done',
             );
         });


### PR DESCRIPTION
Adds a new feature allowing consumers to manipulate the context object before executing the function under test.

This is useful if you want to add some custom logic to the context that isn't catered for in the standard context builder.