### PR TITLE
Add special handling for http responses to assign $return to context.res

### DIFF
--- a/lib/function-runner.js
+++ b/lib/function-runner.js
@@ -74,6 +74,9 @@ function callFunction(context, func, now) {
             if (err) {
                 reject(err);
             } else if (outputs.some(({ name }) => name === '$return')) {
+                if (httpOutput.name === '$return') {
+                    Object.assign(context, { res: propertyBag });
+                }
                 resolve(propertyBag);
             } else {
                 if (propertyBag) {


### PR DESCRIPTION
This allows us to support multiple output bindings with a http `$return` output binding