### PR TITLE
Allow JSON parsing to fail

### DIFF
--- a/lib/bindings/http.js
+++ b/lib/bindings/http.js
@@ -75,6 +75,14 @@ function addInputBinding() {
     throw new Error('Http cannot be an input binding');
 }
 
+function safeJSONParse(text, reviver) {
+    try {
+        return JSON.parse(text, reviver);
+    } catch (e) {
+        return null;
+    }
+}
+
 /**
  * see https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node#request-object
  *
@@ -101,7 +109,7 @@ function createTrigger(method = 'GET', url = 'http://example.com/', headers = {}
     let outBody;
     let outRawBody;
     if (body || rawBody) {
-        outBody = body || JSON.parse(rawBody);
+        outBody = body || safeJSONParse(rawBody) || rawBody;
         outRawBody = rawBody || JSON.stringify(body);
     }
     return {


### PR DESCRIPTION
This allows non-JSON payloads to be sent as `rawBody`, which can happen in the wild (eg: `application/x-www-form-urlencoded`).

If the payload can't be parsed as JSON, then the body will be the `rawBody` value.