### PR TITLE
Allow to send objects to the queue

### DIFF
--- a/lib/bindings/queue-binding.ts
+++ b/lib/bindings/queue-binding.ts
@@ -5,7 +5,7 @@ import { ContextBindings } from '@azure/functions';
 
 export type QueueBindingData = {
     id: string;
-    queueTrigger: string;
+    queueTrigger: string | object;
     dequeueCount: number;
     expirationTime: string;
     insertionTime: string;
@@ -41,7 +41,7 @@ const MESSAGE_MAP: Record<keyof DequeuedMessageItem, keyof QueueBindingData> = {
 };
 
 export class QueueBinding implements Binding {
-    static createFromMessageText(queueTrigger: string): QueueBinding {
+    static createFromMessageText(queueTrigger: string | object): QueueBinding {
         const now = Date.now();
         return new QueueBinding({
             id: uuid(),


### PR DESCRIPTION
Azure allows as to send objects as a messageText. Objects will be converted to JSON
https://learn.microsoft.com/en-us/javascript/api/@azure/service-bus/servicebusmessage?view=azure-node-latest