### PR TITLE
feat: support parsing JSON queue messages

### DIFF
--- a/lib/bindings/queue-binding.ts
+++ b/lib/bindings/queue-binding.ts
@@ -77,6 +77,14 @@ export class QueueBinding implements Binding {
     }
 
     toTrigger(): string | object {
+        // messages that parse as JSON are returned as objects
+        if (typeof this.data.queueTrigger === 'string') {
+            try {
+                return JSON.parse(this.data.queueTrigger);
+            } catch (e) {
+                // swallow error
+            }
+        }
         return this.data.queueTrigger;
     }
 

--- a/test/queue-binding.spec.ts
+++ b/test/queue-binding.spec.ts
@@ -35,12 +35,22 @@ describe('queue-binding', () => {
     });
     it('executes a queue trigger from object', async () => {
         const functionStub = stub().resolves();
-        const queueBinding = QueueBinding.createFromMessageText({test: 'test'});
+        const queueBinding = QueueBinding.createFromMessageText({ test: 'test' });
         await functionRunner(
             functionStub,
             [{ name: 'queueMessage', type: 'queueTrigger', direction: 'in' }],
             { queueMessage: queueBinding },
         );
-        expect(functionStub).to.have.been.calledOnceWithExactly(match.any, {test: 'test'});
+        expect(functionStub).to.have.been.calledOnceWithExactly(match.any, { test: 'test' });
+    });
+    it('executes a queue trigger from JSON', async () => {
+        const functionStub = stub().resolves();
+        const queueBinding = QueueBinding.createFromMessageText(JSON.stringify({ test: true }));
+        await functionRunner(
+            functionStub,
+            [{ name: 'queueMessage', type: 'queueTrigger', direction: 'in' }],
+            { queueMessage: queueBinding },
+        );
+        expect(functionStub).to.have.been.calledOnceWithExactly(match.any, { test: true });
     });
 });


### PR DESCRIPTION
Queue messages can be JSON and the function runtime parses these and returns objects to the function.