### PR TITLE
fix: update function runner return type

### DIFF
--- a/lib/function-runner.ts
+++ b/lib/function-runner.ts
@@ -10,7 +10,7 @@ import { extractBindings } from './utils';
 
 export type AugmentContextCallback = (context: Context) => void;
 
-export async function functionRunner<T extends AzureFunction = AzureFunction>(azFunction: T, bindingDefinitions: BindingDefinition[] | string = [], bindingData: Record<string, Binding> = {}, augmentContext?: AugmentContextCallback): Promise<Awaited<ReturnType<T>> extends void ? Context : ReturnType<T>> {
+export async function functionRunner<T extends AzureFunction = AzureFunction>(azFunction: T, bindingDefinitions: BindingDefinition[] | string = [], bindingData: Record<string, Binding> = {}, augmentContext?: AugmentContextCallback): Promise<Awaited<ReturnType<T>> extends void ? Context : Awaited<ReturnType<T>>> {
     return new Promise((resolve, reject) => {
         const resolver = (err: null | Error, result?: any) => {
             if (err) {


### PR DESCRIPTION
Under some circumstances the type resolution will say the return type is `Promise<Promise<T>>` when using the generic inference.

```ts
functionRunner(func as () => Promise<HttpResponse>, ...);
```

This can result in the return type being `Promise<Promise<HttpResponse>>`, which causes problems.