### PR TITLE
ci: update code coverage output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
           badge: true
           format: markdown
           output: both
+      - name: Add code coverage summary
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This adds a summary output to the actions for the code coverage. Useful for when it is not triggered by a PR. 

It may also be good to remove the PR comments (they are a bit noisy and cause lots of inbox notifications)