### PR TITLE
feat: add `traceparent` value to `traceContext`

### DIFF
--- a/lib/bindings/queue-binding.ts
+++ b/lib/bindings/queue-binding.ts
@@ -1,6 +1,6 @@
 // see https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
 import { Binding } from '../types';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { ContextBindings } from '@azure/functions';
 
 export type QueueBindingData = {

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -7,7 +7,7 @@ import {
     HttpResponseFull,
     Logger,
 } from '@azure/functions';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { extractBindings } from './utils';
 
 function createConsoleLogger(): Logger {

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -7,7 +7,7 @@ import {
     HttpResponseFull,
     Logger,
 } from '@azure/functions';
-import { randomUUID as uuid } from 'crypto';
+import { randomUUID as uuid, randomBytes } from 'crypto';
 import { extractBindings } from './utils';
 
 function createConsoleLogger(): Logger {
@@ -50,7 +50,7 @@ function createBaseContext(azFunction: AzureFunction, bindingDefinitions: Bindin
             invocationId,
         },
         traceContext: {
-            traceparent: null,
+            traceparent: `00-${randomBytes(16).toString('hex')}-${randomBytes(8).toString('hex')}-00`,
             tracestate: null,
             attributes: null,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7340,11 +7340,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
-    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "content-type": "^1.0.5",
-    "uuid": "^10.0.0"
+    "content-type": "^1.0.5"
   }
 }

--- a/test/context-builder.spec.ts
+++ b/test/context-builder.spec.ts
@@ -30,7 +30,7 @@ describe('context-builder', () => {
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             () => {},
         );
-        const { done, invocationId, log } = context;
+        const { done, invocationId, log, traceContext } = context;
 
         expect(context).to.deep.equal({
             invocationId,
@@ -47,12 +47,9 @@ describe('context-builder', () => {
                 retryContext: null,
             },
             log,
-            traceContext: {
-                attributes: null,
-                traceparent: null,
-                tracestate: null,
-            },
+            traceContext,
         });
+        expect(traceContext.traceparent).to.match(/^00-[0-9a-f]{32}-[0-9a-f]{16}-00$/);
     });
     it('creates a context with multiple inputs', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/test/function-runner.spec.ts
+++ b/test/function-runner.spec.ts
@@ -17,7 +17,7 @@ const contextMatcher = match({
         invocationId: match.string,
     },
     traceContext: {
-        traceparent: null,
+        traceparent: match.string,
         tracestate: null,
         attributes: null,
     },

--- a/test/queue-binding.spec.ts
+++ b/test/queue-binding.spec.ts
@@ -1,7 +1,7 @@
 import { match, stub } from 'sinon';
 import { functionRunner, QueueBinding } from '../lib';
 import { expect } from 'chai';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 describe('queue-binding', () => {
     it('executes a queue trigger', async () => {


### PR DESCRIPTION
The trace context is meant to hold data from the traceparent header as defined in the [trace context spec](https://w3c.github.io/trace-context/)

This populates a default value.